### PR TITLE
Upgrade to Pendulum 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ sla_time = sla_calc.calculate(start_time="2019-12-10T01:02:03Z",
                               sla_in_hours=4,
                               province="Zurich")
 ```
+
+## Run tests
+Test are written for the pytest framework. Install it with:
+
+    $ poetry install pytest
+    
+Run the tests with:
+
+    $ poetry run pytest

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,83 +1,110 @@
 [[package]]
-category = "main"
-description = "Generate and work with holidays in Python"
 name = "holidays"
+version = "0.9.12"
+description = "Generate and work with holidays in Python"
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.9.11"
 
 [package.dependencies]
 python-dateutil = "*"
 six = "*"
 
 [[package]]
-category = "main"
-description = "Python datetimes made easy."
 name = "pendulum"
+version = "2.1.2"
+description = "Python datetimes made easy"
+category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.2.5"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
-python-dateutil = ">=2.6.0.0,<3.0.0.0"
-pytzdata = ">=2018.3.0.0"
-tzlocal = ">=1.5.0.0,<2.0.0.0"
+python-dateutil = ">=2.6,<3.0"
+pytzdata = ">=2020.1"
+typing = {version = ">=3.6,<4.0", markers = "python_version < \"3.5\""}
 
 [[package]]
-category = "main"
-description = "Extensions to the standard Python datetime module"
 name = "python-dateutil"
+version = "2.8.1"
+description = "Extensions to the standard Python datetime module"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-version = "2.8.1"
 
 [package.dependencies]
 six = ">=1.5"
 
 [[package]]
-category = "main"
-description = "World timezone definitions, modern and historical"
-name = "pytz"
-optional = false
-python-versions = "*"
-version = "2019.3"
-
-[[package]]
-category = "main"
-description = "The Olson timezone database for Python."
 name = "pytzdata"
+version = "2020.1"
+description = "The Olson timezone database for Python."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2019.3"
 
 [[package]]
-category = "main"
-description = "Python 2 and 3 compatibility utilities"
 name = "six"
+version = "1.15.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-version = "1.13.0"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "typing"
+version = "3.7.4.3"
+description = "Type Hints for Python"
 category = "main"
-description = "tzinfo object for the local timezone"
-name = "tzlocal"
 optional = false
-python-versions = "*"
-version = "1.5.1"
-
-[package.dependencies]
-pytz = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [metadata]
-content-hash = "312e4fb3d85f9cafdee8a232919a8c43bad947927ad9525fe01087f527cd8077"
+lock-version = "1.1"
 python-versions = "^2.7 || ^3.6"
+content-hash = "e616fbd3cfc647661977a5b1235bd3780d875ca4187dbc58adb948db73384528"
 
-[metadata.hashes]
-holidays = ["4b1b6b5afaf5af8adef0d5a7e37d5085c5fcf70c203f641c1f01e205cbf94516", "915fdb92b596cfb66067010759b4384a9c6bc82931311d5bf07fe04920cc11bc", "b8e3914abe7460e866732c1424b6ab4586f3fa01e3149aec3785d012a0d943a4"]
-pendulum = ["4173ce3e81ad0d9d61dbce86f4286c43a26a398270df6a0a89f501f0c28ad27d", "56a347d0457859c84b8cdba161fc37c7df5db9b3becec7881cd770e9d2058b3c", "738878168eb26e5446da5d1f7b3312ae993a542061be8882099c00ef4866b1a2", "95536b33ae152e3c831eb236c1bf9ac9dcfb3b5b98fdbe8e9e601eab6c373897", "c04fcf955e622e97e405e5f6d1b1f4a7adc69d79d82f3609643de69283170d6d", "dd6500d27bb7ccc029d497da4f9bd09549bd3c0ea276dad894ea2fdf309e83f3", "ddaf97a061eb5e2ae37857a8cb548e074125017855690d20e443ad8d9f31e164", "e7df37447824f9af0b58c7915a4caf349926036afd86ad38e7529a6b2f8fc34b", "e9732b8bb214fad2c72ddcbfec07542effa8a8b704e174347ede1ff8dc679cce", "f4eee1e1735487d9d25cc435c519fd4380cb1f82cde3ebad1efbc2fc30deca5b"]
-python-dateutil = ["73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c", "75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"]
-pytz = ["1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d", "b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"]
-pytzdata = ["84c52b9a47d097fcd483f047a544979de6c3a86e94c845e3569e9f8acd0fa071", "fac06f7cdfa903188dc4848c655e4adaee67ee0f2fe08e7daf815cf2a761ee5e"]
-six = ["1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd", "30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"]
-tzlocal = ["4ebeb848845ac898da6519b9b31879cf13b6626f7184c496037b818e238f2c4e"]
+[metadata.files]
+holidays = [
+    {file = "holidays-0.9.12-py2.7.egg", hash = "sha256:7e3e7f56bd8c817b5422b2b74c3dc658293ab289b3e96f58692d301320759cdf"},
+    {file = "holidays-0.9.12-py3.7.egg", hash = "sha256:97e9cd423b7ecbb8c943c7678d9ec7d879a956e645e7ccca46da8f33c9414a32"},
+    {file = "holidays-0.9.12.tar.gz", hash = "sha256:3182c4a6fef8d01a829468362ace9c3bba7645873610535fef53454dbb4ea092"},
+]
+pendulum = [
+    {file = "pendulum-2.1.2-cp27-cp27m-macosx_10_15_x86_64.whl", hash = "sha256:b6c352f4bd32dff1ea7066bd31ad0f71f8d8100b9ff709fb343f3b86cee43efe"},
+    {file = "pendulum-2.1.2-cp27-cp27m-win_amd64.whl", hash = "sha256:318f72f62e8e23cd6660dbafe1e346950281a9aed144b5c596b2ddabc1d19739"},
+    {file = "pendulum-2.1.2-cp35-cp35m-macosx_10_15_x86_64.whl", hash = "sha256:0731f0c661a3cb779d398803655494893c9f581f6488048b3fb629c2342b5394"},
+    {file = "pendulum-2.1.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:3481fad1dc3f6f6738bd575a951d3c15d4b4ce7c82dce37cf8ac1483fde6e8b0"},
+    {file = "pendulum-2.1.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9702069c694306297ed362ce7e3c1ef8404ac8ede39f9b28b7c1a7ad8c3959e3"},
+    {file = "pendulum-2.1.2-cp35-cp35m-win_amd64.whl", hash = "sha256:fb53ffa0085002ddd43b6ca61a7b34f2d4d7c3ed66f931fe599e1a531b42af9b"},
+    {file = "pendulum-2.1.2-cp36-cp36m-macosx_10_15_x86_64.whl", hash = "sha256:c501749fdd3d6f9e726086bf0cd4437281ed47e7bca132ddb522f86a1645d360"},
+    {file = "pendulum-2.1.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c807a578a532eeb226150d5006f156632df2cc8c5693d778324b43ff8c515dd0"},
+    {file = "pendulum-2.1.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:2d1619a721df661e506eff8db8614016f0720ac171fe80dda1333ee44e684087"},
+    {file = "pendulum-2.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:f888f2d2909a414680a29ae74d0592758f2b9fcdee3549887779cd4055e975db"},
+    {file = "pendulum-2.1.2-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:e95d329384717c7bf627bf27e204bc3b15c8238fa8d9d9781d93712776c14002"},
+    {file = "pendulum-2.1.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4c9c689747f39d0d02a9f94fcee737b34a5773803a64a5fdb046ee9cac7442c5"},
+    {file = "pendulum-2.1.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1245cd0075a3c6d889f581f6325dd8404aca5884dea7223a5566c38aab94642b"},
+    {file = "pendulum-2.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:db0a40d8bcd27b4fb46676e8eb3c732c67a5a5e6bfab8927028224fbced0b40b"},
+    {file = "pendulum-2.1.2-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:f5e236e7730cab1644e1b87aca3d2ff3e375a608542e90fe25685dae46310116"},
+    {file = "pendulum-2.1.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:de42ea3e2943171a9e95141f2eecf972480636e8e484ccffaf1e833929e9e052"},
+    {file = "pendulum-2.1.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7c5ec650cb4bec4c63a89a0242cc8c3cebcec92fcfe937c417ba18277d8560be"},
+    {file = "pendulum-2.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:33fb61601083f3eb1d15edeb45274f73c63b3c44a8524703dc143f4212bf3269"},
+    {file = "pendulum-2.1.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:29c40a6f2942376185728c9a0347d7c0f07905638c83007e1d262781f1e6953a"},
+    {file = "pendulum-2.1.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:94b1fc947bfe38579b28e1cccb36f7e28a15e841f30384b5ad6c5e31055c85d7"},
+    {file = "pendulum-2.1.2.tar.gz", hash = "sha256:b06a0ca1bfe41c990bbf0c029f0b6501a7f2ec4e38bfec730712015e8860f207"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
+    {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
+]
+pytzdata = [
+    {file = "pytzdata-2020.1-py2.py3-none-any.whl", hash = "sha256:e1e14750bcf95016381e4d472bad004eef710f2d6417240904070b3d6654485f"},
+    {file = "pytzdata-2020.1.tar.gz", hash = "sha256:3efa13b335a00a8de1d345ae41ec78dd11c9f8807f522d39850f2dd828681540"},
+]
+six = [
+    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
+    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+]
+typing = [
+    {file = "typing-3.7.4.3-py2-none-any.whl", hash = "sha256:283d868f5071ab9ad873e5e52268d611e851c870a2ba354193026f2dfb29d8b5"},
+    {file = "typing-3.7.4.3.tar.gz", hash = "sha256:1187fb9c82fd670d10aa07bbb6cfcfe4bdda42d6fab8d5134f04e8c4d0b71cc9"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/swimlane/sla_calculator"
 
 [tool.poetry.dependencies]
 python = "^2.7 || ^3.6"
-pendulum = "^1"
+pendulum = "2.1.2"
 holidays = "^0.9.11"
 
 [tool.poetry.dev-dependencies]

--- a/sla_calculator/calculator.py
+++ b/sla_calculator/calculator.py
@@ -10,34 +10,34 @@ class SLA_Calculator(object):
         while start_time in country_holidays:
             start_time = start_time.add(days=1)
             start_time = pendulum.datetime(start_time.year, start_time.month, start_time.day, open_hour, 0, 0,
-                                           tzinfo=pendulum.local_timezone())
-        while start_time.is_weekend():
+                                           tz=pendulum.local_timezone())
+        while start_time.day_of_week > 4:  # 0=Monday, 6=Sunday
             start_time = start_time.add(days=1)
             start_time = pendulum.datetime(start_time.year, start_time.month, start_time.day, open_hour, 0, 0,
-                                           tzinfo=pendulum.local_timezone())
+                                           tz=pendulum.local_timezone())
         return start_time
 
     def calculate(self, start_time, open_hour, close_hour, country_name='US', sla_in_hours=4, province=None,
                   state=None):
         sla_time = None
         sla_in_minutes = sla_in_hours * 60
-        start_time = start_time if isinstance(start_time, pendulum.Pendulum) else pendulum.parse(start_time)
+        start_time = start_time if isinstance(start_time, pendulum.DateTime) else pendulum.parse(start_time)
 
         country_holidays = pyholidays.CountryHoliday(country_name, prov=province, state=state)
         start_time = self.check_working_days(start_time, country_holidays, open_hour)
 
         open_time = pendulum.datetime(start_time.year, start_time.month, start_time.day, open_hour,
-                                      0, 0, tzinfo=pendulum.local_timezone())
+                                      0, 0, tz=pendulum.local_timezone())
         close_time = pendulum.datetime(start_time.year, start_time.month, start_time.day,
-                                       close_hour, 0, 0, tzinfo=pendulum.local_timezone())
+                                       close_hour, 0, 0, tz=pendulum.local_timezone())
         if start_time < open_time:
             start_time = open_time
         elif start_time > close_time:
             start_time = open_time.add(days=1)
             open_time = pendulum.datetime(start_time.year, start_time.month, start_time.day, open_hour, 0, 0,
-                                          tzinfo=pendulum.local_timezone())
+                                          tz=pendulum.local_timezone())
             close_time = pendulum.datetime(start_time.year, start_time.month, start_time.day, close_hour, 0, 0,
-                                           tzinfo=pendulum.local_timezone())
+                                           tz=pendulum.local_timezone())
 
         time_left_today = start_time.diff(close_time).in_minutes()
         if time_left_today >= sla_in_minutes:
@@ -48,9 +48,9 @@ class SLA_Calculator(object):
             while tomorrow_minutes > time_left_today:
                 start_time = self.check_working_days(start_time, country_holidays, open_hour)
                 open_time = pendulum.datetime(start_time.year, start_time.month, start_time.day, open_hour, 0, 0,
-                                              tzinfo=pendulum.local_timezone())
+                                              tz=pendulum.local_timezone())
                 close_time = pendulum.datetime(start_time.year, start_time.month, start_time.day, close_hour, 0, 0,
-                                               tzinfo=pendulum.local_timezone())
+                                               tz=pendulum.local_timezone())
                 time_left_today = start_time.diff(close_time).in_minutes()
                 if time_left_today >= sla_in_minutes:
                     sla_time = start_time.add(minutes=tomorrow_minutes)

--- a/test_sla_time.py
+++ b/test_sla_time.py
@@ -1,0 +1,12 @@
+from sla_calculator import SLA_Calculator
+
+
+def test_sla_time():
+    sla_calc = SLA_Calculator()
+
+    sla_time = sla_calc.calculate(start_time="2019-12-10T01:02:03Z",
+                                  open_hour=9,
+                                  close_hour=17,
+                                  country_name="US",
+                                  sla_in_hours=4)
+    assert sla_time.to_iso8601_string() == '2019-12-10T13:00:00-08:00'


### PR DESCRIPTION
Since the latest swimlane version requires pendulum 2.1.2, we need to upgrade the sla_calculator to the same version