### PR TITLE
Changes to calculator.py

### DIFF
--- a/sla_calculator/calculator.py
+++ b/sla_calculator/calculator.py
@@ -7,23 +7,19 @@ class SLA_Calculator(object):
         pass
 
     def check_working_days(self, start_time, country_holidays, open_hour):
-        while start_time in country_holidays:
+        while (start_time.day_of_week in (pendulum.SUNDAY, pendulum.SATURDAY)) or (pendulum.date(start_time.year, start_time.month, start_time.day) in country_holidays):
             start_time = start_time.add(days=1)
             start_time = pendulum.datetime(start_time.year, start_time.month, start_time.day, open_hour, 0, 0,
-                                           tz=pendulum.local_timezone())
-        while start_time.day_of_week > 4:  # 0=Monday, 6=Sunday
-            start_time = start_time.add(days=1)
-            start_time = pendulum.datetime(start_time.year, start_time.month, start_time.day, open_hour, 0, 0,
-                                           tz=pendulum.local_timezone())
+                                            tz=pendulum.local_timezone())
         return start_time
 
     def calculate(self, start_time, open_hour, close_hour, country_name='US', sla_in_hours=4, province=None,
                   state=None):
         sla_time = None
         sla_in_minutes = sla_in_hours * 60
-        start_time = start_time if isinstance(start_time, pendulum.DateTime) else pendulum.parse(start_time)
+        start_time = start_time if isinstance(start_time, pendulum.DateTime) else pendulum.parse(start_time, tz = pendulum.local_timezone())
 
-        country_holidays = pyholidays.CountryHoliday(country_name, prov=province, state=state)
+        country_holidays = list(pyholidays.CountryHoliday(country_name, years=[start_time.year], prov=province, state=state).keys())
         start_time = self.check_working_days(start_time, country_holidays, open_hour)
 
         open_time = pendulum.datetime(start_time.year, start_time.month, start_time.day, open_hour,
@@ -34,6 +30,9 @@ class SLA_Calculator(object):
             start_time = open_time
         elif start_time > close_time:
             start_time = open_time.add(days=1)
+            
+            start_time = self.check_working_days(start_time, country_holidays, open_hour)
+
             open_time = pendulum.datetime(start_time.year, start_time.month, start_time.day, open_hour, 0, 0,
                                           tz=pendulum.local_timezone())
             close_time = pendulum.datetime(start_time.year, start_time.month, start_time.day, close_hour, 0, 0,


### PR DESCRIPTION
Changes:
1. "check_working_days" function: -> merged the "while" instructions in order or avoid the issue when the Monday is a holiday and it's not skipped -> the weekend check is compared to the variables "SUNDAY" and "SATURDAY" within "pendulum" library. This avoids the cases when the machine calendar is set such that SUNDAY = 0

2. "calculate" function: -> since every other parsing is done using "local_timezone()", the start_time should be parsed as well in case the provided value is not of type pendulum.DateTime. This ensures that any comparison will be based only on the actual dates -> updated how the "country_holidays" is populated, The latest version of "holidays" version (0.23) requires a list with years for which will retrieve the dates. Additionally, the returned value is in a dict format now (I assume that this is a changed behavior) and, in order to find in "check_working_days", I kept only the dict keys in a list format -> when the "start_time" is greater than "close_time", and 1 day is added to "start_time", one potential issue was that the new date wasn't checked to make sure it's a working day. Now it's checked.